### PR TITLE
an issue of paired_paths_from_folder function

### DIFF
--- a/basicsr/data/data_util.py
+++ b/basicsr/data/data_util.py
@@ -217,17 +217,29 @@ def paired_paths_from_folder(folders, keys, filename_tmpl):
     input_key, gt_key = keys
 
     input_paths = list(scandir(input_folder))
+    input_paths.sort()
     gt_paths = list(scandir(gt_folder))
+    gt_paths.sort()
     assert len(input_paths) == len(gt_paths), (f'{input_key} and {gt_key} datasets have different number of images: '
                                                f'{len(input_paths)}, {len(gt_paths)}.')
     paths = []
-    for gt_path in gt_paths:
-        basename, ext = osp.splitext(osp.basename(gt_path))
-        input_name = f'{filename_tmpl.format(basename)}{ext}'
+    for idx in range(len(gt_paths)):
+        gt_path = gt_paths[idx]
+        basename_gt, ext_gt = osp.splitext(osp.basename(gt_path))
+        gt_name = f'{filename_tmpl.format(basename_gt)}{ext_gt}'
+        gt_path = osp.join(gt_folder, gt_name)
+        assert gt_name in gt_paths, (f'{gt_name} is not in '
+                                           f'{gt_key}_paths.')
+        input_path = input_paths[idx]
+        basename_input, ext_input = osp.splitext(osp.basename(input_path))
+        input_name = f'{filename_tmpl.format(basename_input)}{ext_input}'
         input_path = osp.join(input_folder, input_name)
-        assert input_name in input_paths, f'{input_name} is not in {input_key}_paths.'
-        gt_path = osp.join(gt_folder, gt_path)
-        paths.append(dict([(f'{input_key}_path', input_path), (f'{gt_key}_path', gt_path)]))
+        assert input_name in input_paths, (f'{input_name} is not in '
+                                           f'{input_key}_paths.')
+        paths.append(
+            dict([(f'{input_key}_path', input_path),
+                  (f'{gt_key}_path', gt_path)]))
+        
     return paths
 
 


### PR DESCRIPTION
Brilliant work, @xinntao ! This framework helps a lot.
Maybe not so many people load paired data from folders,  I got an error when trying to do so:

`AssertionError: kg_t_0914.npy is not in lq_paths`

'kg_t_0914.npy' is one of my groud truth data and it's weird to raise an alert saying it's not in the low quality folder. BTW I have my groud truth data in gt_folder and low quality in lq_folder. I guess this is the case for the oringal design of paired_paths_from_folder function.

So I changed the code a little bit. Hope it helps.
