### PR TITLE
The user can specify the roots of experiments in the config.path

### DIFF
--- a/basicsr/utils/options.py
+++ b/basicsr/utils/options.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import random
 import torch
 import yaml
@@ -14,7 +13,7 @@ def ordered_yaml():
     """Support OrderedDict for yaml.
 
     Returns:
-        tuple: yaml Loader and Dumper.
+        yaml Loader and Dumper.
     """
     try:
         from yaml import CDumper as Dumper
@@ -33,22 +32,6 @@ def ordered_yaml():
     Dumper.add_representer(OrderedDict, dict_representer)
     Loader.add_constructor(_mapping_tag, dict_constructor)
     return Loader, Dumper
-
-
-def yaml_load(f):
-    """Load yaml file or string.
-
-    Args:
-        f (str): File path or a python string.
-
-    Returns:
-        dict: Loaded dict.
-    """
-    if os.path.isfile(f):
-        with open(f, 'r') as f:
-            return yaml.load(f, Loader=ordered_yaml()[0])
-    else:
-        return yaml.load(f, Loader=ordered_yaml()[0])
 
 
 def dict2str(opt, indent_level=1):
@@ -108,7 +91,8 @@ def parse_options(root_path, is_train=True):
     args = parser.parse_args()
 
     # parse yml to dict
-    opt = yaml_load(args.opt)
+    with open(args.opt, mode='r') as f:
+        opt = yaml.load(f, Loader=ordered_yaml()[0])
 
     # distributed settings
     if args.launcher == 'none':
@@ -171,7 +155,9 @@ def parse_options(root_path, is_train=True):
             opt['path'][key] = osp.expanduser(val)
 
     if is_train:
-        experiments_root = osp.join(root_path, 'experiments', opt['name'])
+        experiments_root = opt['path'].get('experiments_root')
+        if experiments_root is None:
+            experiments_root = osp.join(root_path, 'experiments', opt['name'])
         opt['path']['experiments_root'] = experiments_root
         opt['path']['models'] = osp.join(experiments_root, 'models')
         opt['path']['training_states'] = osp.join(experiments_root, 'training_states')
@@ -185,26 +171,11 @@ def parse_options(root_path, is_train=True):
             opt['logger']['print_freq'] = 1
             opt['logger']['save_checkpoint_freq'] = 8
     else:  # test
-        results_root = osp.join(root_path, 'results', opt['name'])
+        results_root = opt['path'].get('results_root')
+        if results_root is None:
+            results_root = osp.join(root_path, 'results', opt['name'])
         opt['path']['results_root'] = results_root
         opt['path']['log'] = results_root
         opt['path']['visualization'] = osp.join(results_root, 'visualization')
 
     return opt, args
-
-
-@master_only
-def copy_opt_file(opt_file, experiments_root):
-    # copy the yml file to the experiment root
-    import sys
-    import time
-    from shutil import copyfile
-    cmd = ' '.join(sys.argv)
-    filename = osp.join(experiments_root, osp.basename(opt_file))
-    copyfile(opt_file, filename)
-
-    with open(filename, 'r+') as f:
-        lines = f.readlines()
-        lines.insert(0, f'# GENERATE TIME: {time.asctime()}\n# CMD:\n# {cmd}\n\n')
-        f.seek(0)
-        f.writelines(lines)


### PR DESCRIPTION
1. The experiment root is specified by opt['path']['experiment_root']
2. The testing root is specified by opt['path']['results_root']