### PR TITLE
The user can specify the roots of experiments in the config.path

### DIFF
--- a/basicsr/utils/options.py
+++ b/basicsr/utils/options.py
@@ -171,8 +171,10 @@ def parse_options(root_path, is_train=True):
             opt['path'][key] = osp.expanduser(val)
 
     if is_train:
-        experiments_root = osp.join(root_path, 'experiments', opt['name'])
-        opt['path']['experiments_root'] = experiments_root
+        experiments_root = opt['path'].get('experiments_root')
+        if experiments_root is None:
+            experiments_root = osp.join(root_path, 'experiments', opt['name'])
+            opt['path']['experiments_root'] = experiments_root
         opt['path']['models'] = osp.join(experiments_root, 'models')
         opt['path']['training_states'] = osp.join(experiments_root, 'training_states')
         opt['path']['log'] = experiments_root
@@ -185,8 +187,10 @@ def parse_options(root_path, is_train=True):
             opt['logger']['print_freq'] = 1
             opt['logger']['save_checkpoint_freq'] = 8
     else:  # test
-        results_root = osp.join(root_path, 'results', opt['name'])
-        opt['path']['results_root'] = results_root
+        results_root = opt['path'].get('results_root')
+        if results_root is None:
+            results_root = osp.join(root_path, 'results', opt['name'])
+            opt['path']['results_root'] = results_root
         opt['path']['log'] = results_root
         opt['path']['visualization'] = osp.join(results_root, 'visualization')
 

--- a/basicsr/utils/options.py
+++ b/basicsr/utils/options.py
@@ -173,8 +173,10 @@ def parse_options(root_path, is_train=True):
     if is_train:
         experiments_root = opt['path'].get('experiments_root')
         if experiments_root is None:
-            experiments_root = osp.join(root_path, 'experiments', opt['name'])
-            opt['path']['experiments_root'] = experiments_root
+            experiments_root = osp.join(root_path, 'experiments')
+        experiments_root = osp.join(experiments_root, opt['name'])
+
+        opt['path']['experiments_root'] = experiments_root
         opt['path']['models'] = osp.join(experiments_root, 'models')
         opt['path']['training_states'] = osp.join(experiments_root, 'training_states')
         opt['path']['log'] = experiments_root
@@ -189,8 +191,10 @@ def parse_options(root_path, is_train=True):
     else:  # test
         results_root = opt['path'].get('results_root')
         if results_root is None:
-            results_root = osp.join(root_path, 'results', opt['name'])
-            opt['path']['results_root'] = results_root
+            results_root = osp.join(root_path, 'results')
+        results_root = osp.join(results_root, opt['name'])
+
+        opt['path']['results_root'] = results_root
         opt['path']['log'] = results_root
         opt['path']['visualization'] = osp.join(results_root, 'visualization')
 


### PR DESCRIPTION
1. The experiment root can be optionally specified by opt['path']['experiment_root']
2. The testing root can be optionally specified by opt['path']['results_root']