### PR TITLE
Update to non-deprecated module.

### DIFF
--- a/basicsr/data/degradations.py
+++ b/basicsr/data/degradations.py
@@ -5,7 +5,7 @@ import random
 import torch
 from scipy import special
 from scipy.stats import multivariate_normal
-from torchvision.transforms.functional_tensor import rgb_to_grayscale
+from torchvision.transforms.functional import rgb_to_grayscale
 
 # -------------------------------------------------------------------- #
 # --------------------------- blur kernels --------------------------- #


### PR DESCRIPTION
This removes a warning that is emitted from `torchvision` 0.15.0.* nightly, and still works with 0.14.1