### PR TITLE
Update psnr_ssim.py

### DIFF
--- a/basicsr/metrics/psnr_ssim.py
+++ b/basicsr/metrics/psnr_ssim.py
@@ -204,8 +204,8 @@ def _ssim_pth(img, img2):
     It is called by func:`calculate_ssim_pt`.
 
     Args:
-        img (Tensor): Images with range [0, 1], shape (n, 3/1, h, w).
-        img2 (Tensor): Images with range [0, 1], shape (n, 3/1, h, w).
+        img (Tensor): Images with range [0, 255], shape (n, 3/1, h, w).
+        img2 (Tensor): Images with range [0, 255], shape (n, 3/1, h, w).
 
     Returns:
         float: SSIM result.


### PR DESCRIPTION
Fix input range typo

In the SSIM implementation, the input range must be from 0 to 255 because c1 is set to (0.01 * 255(==L)) ** 2. However, the docstring states that the input range is from 0 to 1.