### PR TITLE
fix ensemble bug without net_g_ema in SRModel

### DIFF
--- a/basicsr/models/sr_model.py
+++ b/basicsr/models/sr_model.py
@@ -162,7 +162,7 @@ class SRModel(BaseModel):
         else:
             self.net_g.eval()
             with torch.no_grad():
-                out_list = [self.net_g_ema(aug) for aug in lq_list]
+                out_list = [self.net_g(aug) for aug in lq_list]
             self.net_g.train()
 
         # merge results


### PR DESCRIPTION
When the parameter net_g_ema is not set. Program cannot run correctly. Original program will call self.net_g_ema as if the parameter is set when net_g_ema is not set. Then program will crash.

I change the function call while net_g_ema is not set to ensure it work properly.