### PR TITLE
Update degradations.py

### DIFF
--- a/basicsr/data/degradations.py
+++ b/basicsr/data/degradations.py
@@ -5,7 +5,7 @@ import random
 import torch
 from scipy import special
 from scipy.stats import multivariate_normal
-from torchvision.transforms.functional_tensor import rgb_to_grayscale
+from torchvision.transforms.functional import rgb_to_grayscale
 
 # -------------------------------------------------------------------- #
 # --------------------------- blur kernels --------------------------- #


### PR DESCRIPTION
Summary:
Fix #533 functional_tensor not found

The `torchvision.transforms.functional_tensor` module is deprecated since `torchvision` 0.15, and it will be no longer available in 0.17

Change import source of `rgb_to_grayscale` from `torchvision.transforms.functional_tensor` to `torchvision.transforms.functional`, so as to avoid the deprecation warning