### PR TITLE
Fix memory leak problem in augment

### DIFF
--- a/basicsr/data/transforms.py
+++ b/basicsr/data/transforms.py
@@ -119,19 +119,19 @@ def augment(imgs, hflip=True, rotation=True, flows=None, return_status=False):
 
     def _augment(img):
         if hflip:  # horizontal
-            cv2.flip(img, 1, img)
+            img = cv2.flip(img, 1)  # Using inplace operations may cause memory leak
         if vflip:  # vertical
-            cv2.flip(img, 0, img)
+            img = cv2.flip(img, 0)
         if rot90:
             img = img.transpose(1, 0, 2)
         return img
 
     def _augment_flow(flow):
         if hflip:  # horizontal
-            cv2.flip(flow, 1, flow)
+            flow = cv2.flip(flow, 1)
             flow[:, :, 0] *= -1
         if vflip:  # vertical
-            cv2.flip(flow, 0, flow)
+            flow = cv2.flip(flow, 0)
             flow[:, :, 1] *= -1
         if rot90:
             flow = flow.transpose(1, 0, 2)


### PR DESCRIPTION
In the original implementation of BasicSR, the augment function is implemented via inplace operations, which may cause memory leak problem.