### PR TITLE
Fix import error for rgb_to_grayscale

### DIFF
--- a/basicsr/data/degradations.py
+++ b/basicsr/data/degradations.py
@@ -5,7 +5,7 @@ import random
 import torch
 from scipy import special
 from scipy.stats import multivariate_normal
-from torchvision.transforms.functional_tensor import rgb_to_grayscale
+from torchvision.transforms.functional import rgb_to_grayscale
 
 # -------------------------------------------------------------------- #
 # --------------------------- blur kernels --------------------------- #


### PR DESCRIPTION
The import statement for rgb_to_grayscale was referencing the torchvision.transforms.functional_tensor module, which is not available in the current version of torchvision. Updated the import statement to use torchvision.transforms.functional instead, resolving the ModuleNotFoundError.

This commit fixes the issue where the script was failing to run due to the missing module. The change ensures compatibility with the installed version of torchvision and allows the script to execute successfully.