### PR TITLE
fix: use tensorboard instead of tb-nightly

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,7 +14,7 @@ sphinx
 sphinx_intl
 sphinx_markdown_tables
 sphinx_rtd_theme
-tb-nightly
+tensorboard
 torch>=1.7
 torchvision
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pyyaml
 requests
 scikit-image
 scipy
-tb-nightly
+tensorboard
 torch>=1.7
 torchvision
 tqdm


### PR DESCRIPTION
Maybe tb-nightly was needed to run this code when it was introduced 4 years ago in https://github.com/XPixelGroup/BasicSR/commit/35ac620b51de437a529d73228276d8a50e1046d2 but it is not a good idea to still list it as a dependency. Instead it's better to use the stable version of tensorboard. This will make the pip installation of this package easier.