### PR TITLE
Fix Python 3.13 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [build-system]
-requires = [
-  "addict", "future", "lmdb", "numpy", "opencv-python", "Pillow",
-  "pyyaml", "requests", "scikit-image", "scipy", "tb-nightly",
-  "torch", "torchvision", "tqdm", "yapf", "cython", "setuptools"
-]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 packages = ["basicsr"]
 
@@ -21,6 +17,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 license = {text = "Apache-2.0"}
+
+dependencies = [
+  "addict", "future", "lmdb", "numpy", "opencv-python", "Pillow",
+  "pyyaml", "requests", "scikit-image", "scipy", "tb-nightly",
+  "torch", "torchvision", "tqdm", "yapf", "cython"
+]
 
 [project.urls]
 Homepage = "github.com/Disty0/BasicSR"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = [
+  "addict", "future", "lmdb", "numpy", "opencv-python", "Pillow",
+  "pyyaml", "requests", "scikit-image", "scipy", "tb-nightly",
+  "torch", "torchvision", "tqdm", "yapf", "cython", "setuptools"
+]
+build-backend = "setuptools.build_meta"
+packages = ["basicsr"]
+
+[project]
+name = "basicsr"
+version = "1.4.2"
+authors = [
+  { name="Xintao Wang", email="xintao.wang@outlook.com" },
+]
+description = "Open Source Image and Video Super-Resolution Toolbox"
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+license = {text = "Apache-2.0"}
+
+[project.urls]
+Homepage = "github.com/Disty0/BasicSR"
+Issues = "https://github.com/XPixelGroup/BasicSR/issues"

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,7 @@ version_info = ({})
 
 def get_version():
     with open(version_file, 'r') as f:
-        exec(compile(f.read(), version_file, 'exec'))
-    return locals()['__version__']
+        return f.read().split("'")[1]
 
 
 def make_cuda_ext(name, module, sources, sources_cuda=None):


### PR DESCRIPTION
Fixes Python 3.13 compatibility. Closes https://github.com/XPixelGroup/BasicSR/issues/725

exec doesn't update locals with Python 3.13.  
This PR parses the version file as a text instead of running exec.  

BasicSR cannot be installed with Python 3.13 without this PR.  