### PR TITLE
Handle import error for rgb_to_grayscale

### DIFF
--- a/basicsr/data/degradations.py
+++ b/basicsr/data/degradations.py
@@ -5,7 +5,10 @@ import random
 import torch
 from scipy import special
 from scipy.stats import multivariate_normal
-from torchvision.transforms.functional import rgb_to_grayscale
+try:
+    from torchvision.transforms.functional import rgb_to_grayscale
+except Exception:
+    from torchvision.transforms.functional_tensor import rgb_to_grayscale
 
 # -------------------------------------------------------------------- #
 # --------------------------- blur kernels --------------------------- #


### PR DESCRIPTION
### Summary
Fix import error when using `torchvision >= 0.15` where `rgb_to_grayscale` moved from
`torchvision.transforms.functional_tensor` to `torchvision.transforms.functional`.

### Changes
Added backward-compatible import with fallback:
```python
try:
    from torchvision.transforms.functional import rgb_to_grayscale  # torchvision >= 0.15
except Exception:
    from torchvision.transforms.functional_tensor import rgb_to_grayscale  # torchvision <= 0.14
```

### Motivation

In torchvision >= 0.15, the module functional_tensor was removed.

This caused: ModuleNotFoundError: No module named 'torchvision.transforms.functional_tensor' when importing basicsr.data.degradations.

The patch keeps compatibility for both older and new versions of torchvision.


### Tested Environment

Windows 11

Python: 3.9.20

Torch: 2.5.1+cu118

Torchvision: 0.20.1+cu118

Verified that import basicsr.data.degradations works on both old and new torchvision.

### Validation

Ran pip install -e . and confirmed successful import of basicsr.data.degradations.

Backward compatible with torchvision <= 0.14.

---

<img width="1341" height="893" alt="屏幕截图 2025-11-11 222248" src="https://github.com/user-attachments/assets/2e69110d-fbe5-4a8b-9917-e723578ad52a" />
<img width="422" height="202" alt="屏幕截图 2025-11-11 222316" src="https://github.com/user-attachments/assets/49ef4170-daae-4ad7-8a18-0b1671175965" />

---

<img width="1556" height="1057" alt="屏幕截图 2025-11-11 222435" src="https://github.com/user-attachments/assets/61ea516a-e013-49ae-817c-59c228311061" />
<img width="450" height="202" alt="屏幕截图 2025-11-11 222449" src="https://github.com/user-attachments/assets/ea0b6b33-20c8-4bae-999b-623439f64fa7" />

---


